### PR TITLE
use default status bar color

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -37,7 +37,7 @@
 
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="DeckDeckGo | Documentation">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
 
   <meta http-equiv="x-ua-compatible" content="IE=Edge">
 


### PR DESCRIPTION
Improve appearance of app when saved to desktop on iOS devices.  Instead of a black status bar, this setting allows the device to use the default status bar color consistent with the app.  This is especially apparent on devices with a notch.

P.S. If you like this, I'll make PRs on all the other DeckDeckGo projects.

Before:

![deckdeckgo-original](https://user-images.githubusercontent.com/57374/52788820-b761ab80-3027-11e9-9cdd-46547bc31dff.png)


After:

![deckdeckgo-new](https://user-images.githubusercontent.com/57374/52788825-ba5c9c00-3027-11e9-9bfa-031ff8e93d2f.png)
